### PR TITLE
Update ConnectionService.cs to allow on-prem ports with OAuth

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/ConnectionService.cs
+++ b/src/GeneralTools/DataverseClient/Client/ConnectionService.cs
@@ -1471,7 +1471,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 
             IOrganizationService dvService = null;
             Uri OrgWorkingURI = null;
-            if (!IsOnPrem || _eAuthType == AuthenticationType.OAuth) // Use this even if its onPrem, when auth type == oauth. 
+            if (!IsOnPrem)
             {
                 OrgWorkingURI = new Uri(string.Format(SoapOrgUriFormat, _targetInstanceUriToConnectTo.Scheme, _targetInstanceUriToConnectTo.DnsSafeHost));
             }


### PR DESCRIPTION
Otherwise options for on-prem OAuth service client are very limited. On-prem deployment very often use non-standard ports like 444